### PR TITLE
ft(cron): fix typo

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -17,4 +17,4 @@ cron:
 
 - description: Publish a DB update event every day at 4am
   url: /publish/UpdateInformationDB
-  schedule: schedule: every day 04:00
+  schedule: every day 04:00


### PR DESCRIPTION
#### What does this PR do?
- It fixes a typo on `cron.yml`