### PR TITLE
[ft elasticsearch]: Setup elastic search nightly backups 

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -22,3 +22,7 @@ cron:
 - description: Publish a Circle CI get recent builds event hour
   url: /publish/RecentBuildsMetricEvent
   schedule: every 1 hours
+
+- description: Backup elasticsearch data every night at 12am
+  url: /publish/ElasticsearchBackup
+  schedule: every 24 hours


### PR DESCRIPTION
#### What does this PR do?
Sets up a cronjob that backs up elasticsearch data nightly.
#### Description of task completed?
Elastic search data should be backed up into a bucket on GCP every night.
Relevant pivotal tracker stories

[161539950](https://www.pivotaltracker.com/story/show/161539950)